### PR TITLE
made placeholder text color visible

### DIFF
--- a/screens/SharedScreens/QuizScreen/SingleQuestion.tsx
+++ b/screens/SharedScreens/QuizScreen/SingleQuestion.tsx
@@ -29,7 +29,7 @@ function SingleQuestion({
           marginBottom: 5,
         }}
       >
-        <Headline3 style={{ fontSize: 24, fontWeight: 'bold' }}>Q{currentQuestionIndex.toString()}</Headline3>
+        <Headline3 style={{ fontSize: 24, fontWeight: 'bold', paddingTop: 5 }}>Q{currentQuestionIndex.toString()}</Headline3>
         <Headline4>/{maxQuestionIndex.toString()}</Headline4>
       </View>
 

--- a/screens/UserAUnauthorizedScreens/SignUpScreen/SignUpScreen.tsx
+++ b/screens/UserAUnauthorizedScreens/SignUpScreen/SignUpScreen.tsx
@@ -116,7 +116,7 @@ function SignUpScreen() {
         </View>
 
         <TextInput
-          placeholderTextColor={'#88999C'}
+          placeholderTextColor="#88999C"
           placeholder="First Name"
           autoCapitalize="sentences"
           autoCorrect={false}
@@ -126,7 +126,7 @@ function SignUpScreen() {
         {!inputs.firstName.isValid && <LabelText style={styles.errorText}>First Name is a required field</LabelText>}
 
         <TextInput
-          placeholderTextColor={'#88999C'}
+          placeholderTextColor="#88999C"
           placeholder="Last Name"
           autoCapitalize="sentences"
           autoCorrect={false}
@@ -136,7 +136,7 @@ function SignUpScreen() {
         {!inputs.lastName.isValid && <LabelText style={styles.errorText}>Last Name is a required field</LabelText>}
 
         <TextInput
-          placeholderTextColor={'#88999C'}
+          placeholderTextColor="#88999C"
           placeholder="Email"
           keyboardType="email-address"
           autoCorrect={false}
@@ -146,7 +146,7 @@ function SignUpScreen() {
         {!inputs.email.isValid && <LabelText style={styles.errorText}>Invalid email address</LabelText>}
 
         <TextInput
-          placeholderTextColor={'#88999C'}
+          placeholderTextColor="#88999C"
           placeholder="Password"
           secureTextEntry={true}
           autoCorrect={false}
@@ -156,7 +156,7 @@ function SignUpScreen() {
         {!inputs.password.isValid && <LabelText style={styles.errorText}>Invalid Password. Password must be at least 8 characters and contain one number or one special character</LabelText>}
 
         <TextInput
-          placeholderTextColor={'#88999C'}
+          placeholderTextColor="#88999C"
           placeholder="Confirm Password"
           secureTextEntry={true}
           autoCorrect={false}

--- a/screens/UserAUnauthorizedScreens/SignUpScreen/SignUpScreen.tsx
+++ b/screens/UserAUnauthorizedScreens/SignUpScreen/SignUpScreen.tsx
@@ -116,6 +116,7 @@ function SignUpScreen() {
         </View>
 
         <TextInput
+          placeholderTextColor={'#88999C'}
           placeholder="First Name"
           autoCapitalize="sentences"
           autoCorrect={false}
@@ -125,6 +126,7 @@ function SignUpScreen() {
         {!inputs.firstName.isValid && <LabelText style={styles.errorText}>First Name is a required field</LabelText>}
 
         <TextInput
+          placeholderTextColor={'#88999C'}
           placeholder="Last Name"
           autoCapitalize="sentences"
           autoCorrect={false}
@@ -134,6 +136,7 @@ function SignUpScreen() {
         {!inputs.lastName.isValid && <LabelText style={styles.errorText}>Last Name is a required field</LabelText>}
 
         <TextInput
+          placeholderTextColor={'#88999C'}
           placeholder="Email"
           keyboardType="email-address"
           autoCorrect={false}
@@ -143,6 +146,7 @@ function SignUpScreen() {
         {!inputs.email.isValid && <LabelText style={styles.errorText}>Invalid email address</LabelText>}
 
         <TextInput
+          placeholderTextColor={'#88999C'}
           placeholder="Password"
           secureTextEntry={true}
           autoCorrect={false}
@@ -152,6 +156,7 @@ function SignUpScreen() {
         {!inputs.password.isValid && <LabelText style={styles.errorText}>Invalid Password. Password must be at least 8 characters and contain one number or one special character</LabelText>}
 
         <TextInput
+          placeholderTextColor={'#88999C'}
           placeholder="Confirm Password"
           secureTextEntry={true}
           autoCorrect={false}


### PR DESCRIPTION
The Placeholder text had reverted back to almost invisible, have added  placeholderTextColor={'#88999C'} which shows the text on IOS. Shouldn't affect Android