### PR TITLE
Disable button for empty email

### DIFF
--- a/screens/UserAUnauthorizedScreens/LoginScreen/PasswordResetModal.tsx
+++ b/screens/UserAUnauthorizedScreens/LoginScreen/PasswordResetModal.tsx
@@ -52,7 +52,9 @@ function PasswordResetModal({ show, onSubmit, onCancel }: Props) {
 
           <View style={styles.buttonContainer}>
             <Pressable onPress={onCancel} style={styles.button}><ButtonText style={styles.buttonText}>CANCEL</ButtonText></Pressable>
-            <Pressable onPress={onPasswordResetRequest} style={styles.button}><ButtonText style={styles.buttonText}>SUBMIT</ButtonText></Pressable>
+            <Pressable onPress={onPasswordResetRequest} style={styles.button} disabled={!email.trim()}>
+              <ButtonText style={[styles.buttonText, { color: !email.trim() ? 'lightgray' : 'black' }]}>SUBMIT</ButtonText>
+            </Pressable>
           </View>
 
         </Card>


### PR DESCRIPTION
The SUBMIT button in the dialog to request a password reset email was enabled even if no email was entered.
Now it is grayed out and cannot be pressed unless something has been entered into the email field.

<img src="https://github.com/ClimateMind/frontend-native-app/assets/78958483/2edf79c6-b387-426d-97ca-c8d0daea40b7" width=300 />


