### PR TITLE
[CLOSES #246] Ensure Proper Logout

### DIFF
--- a/src/components/CmChip.tsx
+++ b/src/components/CmChip.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
 
-import { CmTypography } from '.';
+import CmTypography from './CmTypography';
 
 interface Props {
   label: string;

--- a/src/navigation/NavigationRoot.tsx
+++ b/src/navigation/NavigationRoot.tsx
@@ -21,7 +21,7 @@ import Colors from 'src/assets/colors';
 import useApiClient from 'src/hooks/useApiClient';
 
 export type RootDrawerNavigationParams = {
-  UserAUnauthorizedScreens: undefined;
+  UserAUnauthorizedScreens: { screen: 'StartScreen' } | undefined;
   UserAAuthorizedScreens: { screen: 'PersonalValuesScreen' | 'ConversationsStack' };
   QuizScreen: { questionSet: 1 | 2 };
   SubmitSetOneScreen: undefined;

--- a/src/screens/SharedScreens/QuizScreen/QuizScreen.tsx
+++ b/src/screens/SharedScreens/QuizScreen/QuizScreen.tsx
@@ -19,6 +19,7 @@ function QuizScreen({ route, navigation }: Props) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
   
+  const isLoggedIn = useAppSelector(state => state.auth.isLoggedIn);
   const quizAnswers = useAppSelector(state => state.quiz.quizAnswers);
   const [questionSets, setQuestionSets] = useState<GetQuestions>();
   const [currentQuestionNumber, setCurrentQuestionNumber] = useState(1);
@@ -39,6 +40,10 @@ function QuizScreen({ route, navigation }: Props) {
     setCurrentQuestionNumber(currentQuestionNumber + 1)
   }
   
+  useEffect(() => {
+    navigation.navigate('UserAUnauthorizedScreens', { screen: 'StartScreen' });
+  }, [isLoggedIn]);
+
   useEffect(() => {
     // Fetch the questions on page load
     // and reverse them so that the last question is displayed first

--- a/src/screens/SharedScreens/SubmitSetOneScreen/SubmitSetOneScreen.tsx
+++ b/src/screens/SharedScreens/SubmitSetOneScreen/SubmitSetOneScreen.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Pressable, StyleSheet } from 'react-native';
 import { DrawerScreenProps } from '@react-navigation/drawer';
 import { RootDrawerNavigationParams } from '../../../navigation/NavigationRoot';
@@ -27,7 +28,11 @@ function SubmitSetOneScreen({ navigation }: Props) {
       navigation.navigate('UserAUnauthorizedScreens');
     }
   }
-  
+
+  useEffect(() => {
+    navigation.navigate('UserAUnauthorizedScreens', { screen: 'StartScreen' });
+  }, [isLoggedIn]);
+
   return (
     <Screen>
       <Section>

--- a/src/screens/SharedScreens/SubmitSetTwoScreen/SubmitSetTwoScreen.tsx
+++ b/src/screens/SharedScreens/SubmitSetTwoScreen/SubmitSetTwoScreen.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Image, StyleSheet } from 'react-native';
 import { DrawerScreenProps } from '@react-navigation/drawer';
 import { RootDrawerNavigationParams } from '../../../navigation/NavigationRoot';
@@ -23,6 +24,10 @@ function SubmitSetTwoScreen({ navigation }: Props) {
       navigation.navigate('UserAUnauthorizedScreens');
     }
   }
+
+  useEffect(() => {
+    navigation.navigate('UserAUnauthorizedScreens', { screen: 'StartScreen' });
+  }, [isLoggedIn]);
 
   return (
     <Screen>


### PR DESCRIPTION
<!-- title: [CLOSES #<issue_number>] Title of the Pull Request -->

## Description
When a logged in user retakes the quiz and logs out through the drawer while on the QuizScreen or one of the two SubmitScreens, he will be logged out but stays on that screen. This is a buggy behavior that we want to avoid.

## Changes Made
Added useEffect hooks into those three screens so that they navigate to the StartScreen on change of isLoggedIn.

## Checklist
- [x] I have tested this code.
- [x] I have updated the documentation.
- [x] I don't add technical debt with this pr.

