### PR TITLE
Fixed issue with incorrect env url

### DIFF
--- a/src/screens/UserAAuthorizedScreens/ConversationsScreen/ConversationsScreen.tsx
+++ b/src/screens/UserAAuthorizedScreens/ConversationsScreen/ConversationsScreen.tsx
@@ -29,7 +29,7 @@ function ConversationsScreen() {
 
     try {
       const result = await apiClient.createConversationInvite(recipient);
-      setConversationLink(process.env.WEB_URL + '/landing/' + result.conversationId);
+      setConversationLink(process.env.EXPO_PUBLIC_WEB_URL + '/landing/' + result.conversationId);
 
       setShowCopyLinkModal(true);
     } catch (e) {


### PR DESCRIPTION
<!-- title: [CLOSES #<issue_number>] Title of the Pull Request -->

## Description
This PR fixes an issue with the process.env being incorrectly set for the copy link on the conversations screen.

## Changes Made
changed process.env.WEB_URL to process.env.EXPO_PUBLIC_WEB_URL

## Checklist
- [x ] I have tested this code.
- [ ] I have updated the documentation.
- [x] I don't add technical debt with this pr.

## Additional Comments
Add any additional comments or notes for reviewers.
