### PR TITLE
[CLOSES #300] Different MORE Buttons for Conversation Cards

### DIFF
--- a/src/screens/UserAAuthorizedScreens/ConversationsScreen/ConversationsIntroCard.tsx
+++ b/src/screens/UserAAuthorizedScreens/ConversationsScreen/ConversationsIntroCard.tsx
@@ -24,7 +24,7 @@ function ConversationsIntroCard() {
       </>}
 
       <Pressable onPress={() => setExpanded(current => !current)} style={styles.moreLessButton}>
-        <CmTypography variant='body' style={{ letterSpacing: 1, fontWeight: 'bold' }}>{expanded ? 'LESS' : 'MORE'}</CmTypography>
+        <CmTypography variant='button' style={{ letterSpacing: 1 }}>{expanded ? 'LESS' : 'MORE'}</CmTypography>
       </Pressable>
 
     </Card>


### PR DESCRIPTION
<!-- title: [CLOSES #<issue_number>] Title of the Pull Request -->

## Description
Update the styling for the MORE button of the ConversationsIntroCard do match the MORE button of all the other ConversationCards.

## Changes Made
Updated the text style for the MORE button of the ConversationsIntroCard.

## Screenshots
If applicable, add screenshots to showcase the changes visually.
<!-- After copy / pasting an image here, you can put the source in an img tag to choose a width for the image -->
**Before**
<img src="https://github.com/ClimateMind/frontend-native-app/assets/78958483/5377cf71-892a-4f2c-9c82-e6e78481587f" width=300 />

**After**
<img src="https://github.com/ClimateMind/frontend-native-app/assets/78958483/78ff23ea-eb48-4fbf-9a16-8762f7a07fa8" width=300 />]()

## Checklist
- [x] I have tested this code.
- [x] I have updated the documentation.
- [x] I don't add technical debt with this pr.

## Additional Comments
Add any additional comments or notes for reviewers.
