### PR TITLE
[CLOSES #302] Clicking 'See How You Align' or 'View Selected Topics' Buttons in Conversation Card won't open the Modal

### DIFF
--- a/src/screens/UserAAuthorizedScreens/ConversationsScreen/SeeHowYouAlignModal.tsx
+++ b/src/screens/UserAAuthorizedScreens/ConversationsScreen/SeeHowYouAlignModal.tsx
@@ -26,10 +26,6 @@ function SeeHowYouAlignModal({ open, conversation, onClose, onViewTopics }: Prop
   const [overallSimilarityScore, setOverallSimilarityScore] = useState<number>();
 
   useEffect(() => {
-    if (conversation.state < 2) {
-      return;
-    }
-
     setUserBName(conversation.userB.name);
 
     apiClient.getAlignmentScores(conversation.alignmentScoresId)
@@ -41,7 +37,7 @@ function SeeHowYouAlignModal({ open, conversation, onClose, onViewTopics }: Prop
       .catch((error) => console.log(error));
   }, [conversation]);
 
-  if (!open || conversation.state <= 2 || !userBName || !topSharedValue || !overallSimilarityScore) {
+  if (!open || !userBName || !topSharedValue || !overallSimilarityScore) {
     return null;
   }
 

--- a/src/screens/UserAAuthorizedScreens/ConversationsScreen/ViewSelectedTopicsModal.tsx
+++ b/src/screens/UserAAuthorizedScreens/ConversationsScreen/ViewSelectedTopicsModal.tsx
@@ -32,8 +32,6 @@ function ViewSelectedTopicsModal({ open, conversation, onClose }: Props) {
   const [showSolutionDetails, setShowSolutionDetails] = useState(false);
 
   useEffect(() => {
-    if (conversation.state < 2) return;
-
     apiClient.getSelectedTopics(conversation.conversationId)
       .then(response => {
         setClimateEffect(response.climateEffects[0]);


### PR DESCRIPTION
<!-- title: [CLOSES #<issue_number>] Title of the Pull Request -->

## Description
We had the bug that pressing the buttons in the ConversationCard won't open the modal, but just enables someone to click the next button.

## Changes Made
Removed the state tests in the modal components.

## Checklist
- [X] I have tested this code.
- [X] I have updated the documentation.
- [X] I don't add technical debt with this pr.
