### PR TITLE
[CLOSES #304] Additional Spaces Around userBs Name

### DIFF
--- a/src/components/CmTypography.tsx
+++ b/src/components/CmTypography.tsx
@@ -7,7 +7,7 @@ interface Props extends TextProps {
 }
 
 function ButtonText({ children, variant, style, ...rest }: Props) {
-  let textContent = Array.isArray(children) ? children.join(' ') : children;
+  let textContent = Array.isArray(children) ? children.map(child => child.trim()).join(' ') : children;
   textContent = textContent[0].toUpperCase() + textContent.slice(1);
 
   let textStyle: StyleProp<TextStyle>;

--- a/src/components/CmTypography.tsx
+++ b/src/components/CmTypography.tsx
@@ -1,15 +1,11 @@
 import { StyleSheet, StyleProp, Text, TextProps, TextStyle } from 'react-native';
 
-interface Props extends TextProps {
-  children: string | string[];
+interface Props extends React.PropsWithChildren, TextProps {
   variant: 'h1' | 'h2' | 'h3' | 'h4' | 'body' | 'body-italics' | 'button' | 'caption' | 'label' | 'overline';
   style?: StyleProp<TextStyle>;
 }
 
 function ButtonText({ children, variant, style, ...rest }: Props) {
-  let textContent = Array.isArray(children) ? children.map(child => child.trim()).join(' ') : children;
-  textContent = textContent[0].toUpperCase() + textContent.slice(1);
-
   let textStyle: StyleProp<TextStyle>;
 
   switch (variant) {
@@ -50,7 +46,7 @@ function ButtonText({ children, variant, style, ...rest }: Props) {
 
   return (
     <Text style={[textStyle, style]} {...rest}>
-      {textContent}
+      {children}
     </Text>
   );
 }


### PR DESCRIPTION
<!-- title: [CLOSES #<issue_number>] Title of the Pull Request -->

## Description
Remove additional spaces around userBs name.

## Changes Made
Updated the CmTypography component. The way it concatenated the strings somehow introduced those additional spaces, so now the children have a standard React.ReactNode type instead of the string | string[]

## Screenshots
If applicable, add screenshots to showcase the changes visually.
<!-- After copy / pasting an image here, you can put the source in an img tag to choose a width for the image -->
**Fixed**
<img src="https://github.com/ClimateMind/frontend-native-app/assets/78958483/d79f952e-a9fc-4e6d-96da-22971cd063b2" width=300 />

## Checklist
- [X] I have tested this code.
- [X] I have updated the documentation.
- [X] I don't add technical debt with this pr.

