### PR TITLE
Added a caption for the text

### DIFF
--- a/src/screens/UserAAuthorizedScreens/ConversationsScreen/ConversationsScreen.tsx
+++ b/src/screens/UserAAuthorizedScreens/ConversationsScreen/ConversationsScreen.tsx
@@ -55,7 +55,7 @@ function ConversationsScreen() {
                 share it, so they can take the quiz, discover your shared values, and
                 pick topics to talk about.
               </CmTypography>
-              <CmTypography variant="caption">
+              <CmTypography variant="caption" style={{ textAlign: 'center' }}>
                 We will send you an email when they agree to share their results with you!
               </CmTypography>
               <CmTypography variant='label' style={styles.label}>Name of recipient</CmTypography>

--- a/src/screens/UserAAuthorizedScreens/ConversationsScreen/ConversationsScreen.tsx
+++ b/src/screens/UserAAuthorizedScreens/ConversationsScreen/ConversationsScreen.tsx
@@ -12,7 +12,6 @@ import ConversationsDrawer from './ConversationsDrawer';
 import CopyLinkModal from './CopyLinkModal';
 import { showErrorToast } from 'src/components/ToastMessages';
 import { CmTypography } from 'src/components';
-import { Caption } from 'src/stories/CmTypography.stories';
 
 function ConversationsScreen() {
   const apiClient = useApiClient();

--- a/src/screens/UserAAuthorizedScreens/ConversationsScreen/ConversationsScreen.tsx
+++ b/src/screens/UserAAuthorizedScreens/ConversationsScreen/ConversationsScreen.tsx
@@ -12,6 +12,7 @@ import ConversationsDrawer from './ConversationsDrawer';
 import CopyLinkModal from './CopyLinkModal';
 import { showErrorToast } from 'src/components/ToastMessages';
 import { CmTypography } from 'src/components';
+import { Caption } from 'src/stories/CmTypography.stories';
 
 function ConversationsScreen() {
   const apiClient = useApiClient();
@@ -54,7 +55,9 @@ function ConversationsScreen() {
                 share it, so they can take the quiz, discover your shared values, and
                 pick topics to talk about.
               </CmTypography>
-
+              <CmTypography variant="caption">
+                We will send you an email when they agree to share their results with you!
+              </CmTypography>
               <CmTypography variant='label' style={styles.label}>Name of recipient</CmTypography>
               <TextInput
                 placeholder='Try "Peter Smith" or "Mom"'


### PR DESCRIPTION
<!-- title: [CLOSES #<issue_number>] Title of the Pull Request -->

## Description
Added text to match Climate Mind website conversation screen. Added a cmTypography Component to the conversations screen with a variant equal to 'caption'.

## Changes Made
Added a cmTypography Component to the conversations screen with variant equal to caption

## Screenshots
If applicable, add screenshots to showcase the changes visually.
![Simulator Screenshot - iPhone 12 - 2023-10-23 at 15 50 20](https://github.com/ClimateMind/frontend-native-app/assets/39728053/21c979d4-0ce8-4af9-b564-84fc9254fe0a)

## Checklist
- [x] I have tested this code.
- [x] I have updated the documentation.
- [x] I don't add technical debt with this pr.

## Additional Comments
Add any additional comments or notes for reviewers.
