### PR TITLE
321 copy link button gets off screen for long userb names

### DIFF
--- a/src/screens/UserAAuthorizedScreens/ConversationsScreen/ConversationCard.tsx
+++ b/src/screens/UserAAuthorizedScreens/ConversationsScreen/ConversationCard.tsx
@@ -81,7 +81,7 @@ function ConversationCard({ conversation, onDelete }: Props) {
       <Card style={[{ padding: 15 }, { backgroundColor: conversationState === 5 ? '#BDFADC' : 'white' }]}>
 
         <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-          <CmTypography variant='caption'>{headerText[conversationState]}</CmTypography>
+          <CmTypography variant='caption' style={{ flexShrink: 1 }}>{headerText[conversationState]}</CmTypography>
           {expanded && <Pressable onPress={copyLink}><Text>COPY LINK</Text></Pressable>}
           {!expanded &&  conversationState > 0 && conversationState < 5 && <NotifyIcon />}
         </View>

--- a/src/screens/UserAAuthorizedScreens/ConversationsScreen/ConversationsScreen.tsx
+++ b/src/screens/UserAAuthorizedScreens/ConversationsScreen/ConversationsScreen.tsx
@@ -64,6 +64,7 @@ function ConversationsScreen() {
                 style={styles.input}
                 value={recipient}
                 placeholderTextColor={'#88999C'}
+                maxLength={20}
               />
               <SimpleWhiteTextButton style={styles.createLinkButton} disabled={recipient === ''} text='CREATE LINK' onPress={showModal} />
             </KeyboardAvoidingView>


### PR DESCRIPTION
<!-- title: [CLOSES #<issue_number>] Title of the Pull Request -->

## Description
Added max 20 chars for the input field on the conversation screen so a toast error isn't produced. Need to address the message on the toast but this would work in the meantime? Please remove it if not happy with the solution.  Also set flexShrink: 1 on the conversationCard header to contain the text. 

## Changes Made
ConversationScreen - input field set max 20 chars
ConversationCard - header set flexShrink

## Screenshots
If applicable, add screenshots to showcase the changes visually.
<!-- After copy / pasting an image here, you can put the source in an img tag to choose a width for the image -->
<!-- <img src="" width=300 /> -->

## Checklist
- [x] I have tested this code.
- [x] I have updated the documentation.
- [x] I don't add technical debt with this pr.

## Additional Comments
Please note there are some unused imports for MUI. I didn't remove these as I don't know if they were there intentionally.
