### PR TITLE
325 improve styling of detail pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend-native-app",
       "version": "1.0.0",
       "dependencies": {
+        "@expo/html-elements": "^0.5.1",
         "@react-native-async-storage/async-storage": "1.18.2",
         "@react-navigation/bottom-tabs": "^6.5.10",
         "@react-navigation/drawer": "^6.6.5",
@@ -2765,6 +2766,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@expo/html-elements": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@expo/html-elements/-/html-elements-0.5.1.tgz",
+      "integrity": "sha512-BDAVI3ayykNykAeAc3B2USSiA244te2WAJDYske/AtDnm/AWZM/DE9lCwSkysuu7uOMcNp78LM2L/v6TwvxqZQ=="
     },
     "node_modules/@expo/image-utils": {
       "version": "0.3.22",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@expo/html-elements": "^0.5.1",
     "@react-native-async-storage/async-storage": "1.18.2",
     "@react-navigation/bottom-tabs": "^6.5.10",
     "@react-navigation/drawer": "^6.6.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@expo/html-elements": "^0.5.1",
     "@react-native-async-storage/async-storage": "1.18.2",
     "@react-navigation/bottom-tabs": "^6.5.10",
     "@react-navigation/drawer": "^6.6.5",

--- a/src/screens/UserAAuthorizedScreens/ClimateDetailsScreen/ClimateDetailsScreen.tsx
+++ b/src/screens/UserAAuthorizedScreens/ClimateDetailsScreen/ClimateDetailsScreen.tsx
@@ -12,13 +12,12 @@ import Section from 'src/components/Screen/Section';
 import Content from 'src/components/Screen/Content';
 import { CmTypography } from 'src/components';
 import BackButton from 'src/components/BackButton';
-
+import { A } from '@expo/html-elements';
 type Props = NativeStackScreenProps<ClimateFeedStackParams, 'ClimateDetailsScreen'>;
 
 function ClimateDetailsScreen({ navigation, route }: Props) {
   const climateEffect = route.params.climateEffect;
   const [selectedTab, setSelectedTab] = useState(0);
-
   return (
     <Screen style={{ backgroundColor: 'white' }}>
       <Section>
@@ -35,7 +34,7 @@ function ClimateDetailsScreen({ navigation, route }: Props) {
             {climateEffect.effectSolutions.map(solution => <View style={{ marginVertical: 20 }} key={solution.solutionTitle}><ActionCard solution={solution} /></View>)}
           </View>}
 
-          {selectedTab === 1 && climateEffect.effectSources.map(source => <View key={source} style={styles.links}><CmTypography variant='label' style={styles.link}>{source}</CmTypography></View>)}
+          {selectedTab === 1 && climateEffect.effectSources.map(source => <View key={source} style={styles.links}><CmTypography variant='label' style={styles.link}><A href={source}>{source}</A></CmTypography></View>)}
         </Content>
       </Section>
     </Screen>
@@ -60,11 +59,12 @@ const styles = StyleSheet.create({
     padding: 20,
   },
   links: {
-    padding: 10,
-    alignSelf:'flex-start'
+    // padding: 10,
+    // alignSelf:'flex-start'
   },
   link: {
-    paddingHorizontal: 20,
+    // paddingHorizontal: 20,
+    marginTop:20,
     textDecorationLine: 'underline',
     lineHeight: 20,
   },

--- a/src/screens/UserAAuthorizedScreens/ClimateDetailsScreen/ClimateDetailsScreen.tsx
+++ b/src/screens/UserAAuthorizedScreens/ClimateDetailsScreen/ClimateDetailsScreen.tsx
@@ -1,18 +1,17 @@
 import { useState } from 'react';
-import { Image, StyleSheet, View } from 'react-native';
+import { Image, Pressable, StyleSheet, View } from 'react-native';
 
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { ClimateFeedStackParams } from 'src/navigation/Stacks/ClimateFeedStack';
 import ActionCard from './ActionCard';
 import DetailsSourcesTab from 'src/components/DetailsSourcesTabs';
 
-import { capitalizeFirstLetter } from 'src/utils';
+import { capitalizeFirstLetter, openUrl } from 'src/utils';
 import Screen from 'src/components/Screen/Screen';
 import Section from 'src/components/Screen/Section';
 import Content from 'src/components/Screen/Content';
 import { CmTypography } from 'src/components';
 import BackButton from 'src/components/BackButton';
-import { A } from '@expo/html-elements';
 
 type Props = NativeStackScreenProps<ClimateFeedStackParams, 'ClimateDetailsScreen'>;
 
@@ -35,7 +34,9 @@ function ClimateDetailsScreen({ navigation, route }: Props) {
             {climateEffect.effectSolutions.map(solution => <View style={{ marginVertical: 20 }} key={solution.solutionTitle}><ActionCard solution={solution} /></View>)}
           </View>}
 
-          {selectedTab === 1 && climateEffect.effectSources.map(source => <View key={source} style={styles.links}><CmTypography variant='label' style={styles.link}><A href={source}>{source}</A></CmTypography></View>)}
+          {selectedTab === 1 && climateEffect.effectSources.map(source => <View key={source} style={styles.links}>
+            <Pressable onPress={() => openUrl(source)}><CmTypography variant='label' style={styles.link}>{source}</CmTypography></Pressable>
+          </View>)}
         </Content>
       </Section>
     </Screen>
@@ -60,12 +61,11 @@ const styles = StyleSheet.create({
     padding: 20,
   },
   links: {
-    // padding: 10,
-    // alignSelf:'flex-start'
+    alignSelf: 'flex-start',
   },
   link: {
-    // paddingHorizontal: 20,
-    marginTop:20,
+    paddingHorizontal: 20,
+    marginTop: 20,
     textDecorationLine: 'underline',
     lineHeight: 20,
   },

--- a/src/screens/UserAAuthorizedScreens/ClimateDetailsScreen/ClimateDetailsScreen.tsx
+++ b/src/screens/UserAAuthorizedScreens/ClimateDetailsScreen/ClimateDetailsScreen.tsx
@@ -13,6 +13,7 @@ import Content from 'src/components/Screen/Content';
 import { CmTypography } from 'src/components';
 import BackButton from 'src/components/BackButton';
 import { A } from '@expo/html-elements';
+
 type Props = NativeStackScreenProps<ClimateFeedStackParams, 'ClimateDetailsScreen'>;
 
 function ClimateDetailsScreen({ navigation, route }: Props) {

--- a/src/screens/UserAAuthorizedScreens/ClimateDetailsScreen/ClimateDetailsScreen.tsx
+++ b/src/screens/UserAAuthorizedScreens/ClimateDetailsScreen/ClimateDetailsScreen.tsx
@@ -61,6 +61,7 @@ const styles = StyleSheet.create({
   },
   links: {
     padding: 10,
+    alignSelf:'flex-start'
   },
   link: {
     paddingHorizontal: 20,

--- a/src/screens/UserAAuthorizedScreens/ClimateFeedScreen/ActionCardHeader.tsx
+++ b/src/screens/UserAAuthorizedScreens/ClimateFeedScreen/ActionCardHeader.tsx
@@ -30,7 +30,6 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     width: '100%',
-    height: 100,
   },
   imageContainer: {
     width: '20%',
@@ -41,6 +40,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     width: '80%',
     gap: -5,
+    paddingVertical: 10,
   },
   title: {
     width: '90%',

--- a/src/screens/UserAAuthorizedScreens/ClimateFeedScreen/ActionCardHeader.tsx
+++ b/src/screens/UserAAuthorizedScreens/ClimateFeedScreen/ActionCardHeader.tsx
@@ -30,16 +30,17 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     paddingVertical: 20,
+    width: '100%',
+    height: 100,
   },
   imageContainer: {
-    width: 60,
-    height: 50,
+  width:'20%',
     justifyContent: 'center',
     alignItems: 'center',
   },
   textContainer: {
     justifyContent: 'center',
-    width: '90%',
+    width: '80%',
     gap: -5,
   },
   title: {

--- a/src/screens/UserAAuthorizedScreens/ClimateFeedScreen/ActionCardHeader.tsx
+++ b/src/screens/UserAAuthorizedScreens/ClimateFeedScreen/ActionCardHeader.tsx
@@ -34,7 +34,7 @@ const styles = StyleSheet.create({
     height: 100,
   },
   imageContainer: {
-  width:'20%',
+    width: '20%',
     justifyContent: 'center',
     alignItems: 'center',
   },

--- a/src/screens/UserAAuthorizedScreens/ClimateFeedScreen/ActionCardHeader.tsx
+++ b/src/screens/UserAAuthorizedScreens/ClimateFeedScreen/ActionCardHeader.tsx
@@ -29,7 +29,6 @@ function ActionCardHeader({ effectSolution, color = '#FDED6D' }: Props) {
 const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
-    paddingVertical: 20,
     width: '100%',
     height: 100,
   },

--- a/src/screens/UserAAuthorizedScreens/ConversationsScreen/ActionDetailsModal.tsx
+++ b/src/screens/UserAAuthorizedScreens/ConversationsScreen/ActionDetailsModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Image, Modal, Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 
-import { capitalizeFirstLetter } from 'src/utils';
+import { capitalizeFirstLetter, openUrl } from 'src/utils';
 import Colors from 'src/assets/colors';
 import ClimateEffect2 from 'src/types/ClimateEffect2';
 import ClimateEffect3 from 'src/types/ClimateEffect3';
@@ -57,7 +57,9 @@ function ActionDetailsModal({ open, action, onClose }: Props) {
             <CmTypography variant='body' style={styles.text}>{actionDetails.longDescription}</CmTypography>
           </View>}
 
-          {selectedTab === 1 && actionDetails.effectSources.map(source => <View key={source} style={styles.links}><CmTypography variant='label' style={styles.link}>{source}</CmTypography></View>)}
+          {selectedTab === 1 && actionDetails.effectSources.map(source => <View key={source} style={styles.links}>
+            <Pressable onPress={() => openUrl(source)}><CmTypography variant='label' style={styles.link}>{source}</CmTypography></Pressable>
+          </View>)}
 
         </ScrollView>
       </View>
@@ -90,10 +92,11 @@ const styles = StyleSheet.create({
     padding: 20,
   },
   links: {
-    padding: 10,
+    alignSelf: 'flex-start',
   },
   link: {
     paddingHorizontal: 20,
+    marginTop: 20,
     textDecorationLine: 'underline',
     lineHeight: 20,
   },

--- a/src/screens/UserAAuthorizedScreens/ConversationsScreen/SolutionDetailsModal.tsx
+++ b/src/screens/UserAAuthorizedScreens/ConversationsScreen/SolutionDetailsModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Image, Modal, Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 
+import { openUrl } from 'src/utils';
 import Colors from 'src/assets/colors';
 import useApiClient from 'src/hooks/useApiClient';
 import Solution3 from 'src/types/Solution3';
@@ -56,7 +57,10 @@ function SolutionDetailsModal({ open, solution, onClose }: Props) {
           <DetailsSourcesTab onTabChanged={(tab) => setSelectedTab(tab)} />
 
           {selectedTab === 0 && <View><CmTypography variant='body' style={styles.text}>{solutionDetails.longDescription}</CmTypography></View>}
-          {selectedTab === 1 && solutionDetails.solutionSources.map(source => <View key={source} style={styles.links}><CmTypography variant='label' style={styles.link}>{source}</CmTypography></View>)}
+
+          {selectedTab === 1 && solutionDetails.solutionSources.map(source => <View key={source} style={styles.links}>
+            <Pressable onPress={() => openUrl(source)}><CmTypography variant='label' style={styles.link}>{source}</CmTypography></Pressable>
+          </View>)}
         </ScrollView>
       </View>
     </Modal>
@@ -87,10 +91,11 @@ const styles = StyleSheet.create({
     padding: 20,
   },
   links: {
-    padding: 10,
+    alignSelf: 'flex-start',
   },
   link: {
     paddingHorizontal: 20,
+    marginTop: 20,
     textDecorationLine: 'underline',
     lineHeight: 20,
   },

--- a/src/screens/UserAAuthorizedScreens/MythDetailsScreen/MythDetailsScreen.tsx
+++ b/src/screens/UserAAuthorizedScreens/MythDetailsScreen/MythDetailsScreen.tsx
@@ -32,7 +32,7 @@ function MythDetailsScreen({ navigation, route }: Props) {
             <DetailsSourcesTab detailsTabName='Flawed Logic' onTabChanged={(tab) => setSelectedTab(tab)} />
           </View>
 
-          {selectedTab === 0 && <CmTypography variant='caption' style={styles.description}>{myth.faultyLogicDescription}</CmTypography>}
+          {selectedTab === 0 && <CmTypography variant='body' style={styles.description}>{myth.faultyLogicDescription}</CmTypography>}
           {selectedTab === 1 && myth.mythSources.map(source => <CmTypography variant='label' key={source} style={styles.link}>{source}</CmTypography>)}
         </Content>
       </Section>

--- a/src/screens/UserAAuthorizedScreens/MythDetailsScreen/MythDetailsScreen.tsx
+++ b/src/screens/UserAAuthorizedScreens/MythDetailsScreen/MythDetailsScreen.tsx
@@ -10,6 +10,7 @@ import Content from 'src/components/Screen/Content';
 import { CmTypography } from 'src/components';
 import DetailsSourcesTab from 'src/components/DetailsSourcesTabs';
 import BackButton from 'src/components/BackButton';
+import { A } from '@expo/html-elements';
 
 type Props = NativeStackScreenProps<MythsFeedStackParams, 'MythDetailsScreen'>;
 
@@ -33,7 +34,7 @@ function MythDetailsScreen({ navigation, route }: Props) {
           </View>
 
           {selectedTab === 0 && <CmTypography variant='body' style={styles.description}>{myth.faultyLogicDescription}</CmTypography>}
-          {selectedTab === 1 && myth.mythSources.map(source => <CmTypography variant='label' key={source} style={styles.link}>{source}</CmTypography>)}
+          {selectedTab === 1 && myth.mythSources.map(source => <CmTypography variant='label' key={source} style={styles.link}><A href={source}>{source}</A></CmTypography>)}
         </Content>
       </Section>
     </Screen>

--- a/src/screens/UserAAuthorizedScreens/MythDetailsScreen/MythDetailsScreen.tsx
+++ b/src/screens/UserAAuthorizedScreens/MythDetailsScreen/MythDetailsScreen.tsx
@@ -1,16 +1,16 @@
 import { useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Pressable, StyleSheet, View } from 'react-native';
 
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { MythsFeedStackParams } from 'src/navigation/Stacks/MythsFeedStack';
 
+import { openUrl } from 'src/utils';
 import Screen from 'src/components/Screen/Screen';
 import Section from 'src/components/Screen/Section';
 import Content from 'src/components/Screen/Content';
 import { CmTypography } from 'src/components';
 import DetailsSourcesTab from 'src/components/DetailsSourcesTabs';
 import BackButton from 'src/components/BackButton';
-import { A } from '@expo/html-elements';
 
 type Props = NativeStackScreenProps<MythsFeedStackParams, 'MythDetailsScreen'>;
 
@@ -34,7 +34,10 @@ function MythDetailsScreen({ navigation, route }: Props) {
           </View>
 
           {selectedTab === 0 && <CmTypography variant='body' style={styles.description}>{myth.faultyLogicDescription}</CmTypography>}
-          {selectedTab === 1 && myth.mythSources.map(source => <CmTypography variant='label' key={source} style={styles.link}><A href={source}>{source}</A></CmTypography>)}
+
+          {selectedTab === 1 && myth.mythSources.map(source => <View key={source} style={styles.links}>
+            <Pressable onPress={() => openUrl(source)}><CmTypography variant='label' key={source} style={styles.link}>{source}</CmTypography></Pressable>
+          </View>)}
         </Content>
       </Section>
     </Screen>
@@ -49,7 +52,12 @@ const styles = StyleSheet.create({
     letterSpacing: 1,
     lineHeight: 20,
   },
+  links: {
+    alignSelf: 'flex-start',
+  },
   link: {
+    paddingHorizontal: 20,
+    marginTop: 20,
     textDecorationLine: 'underline',
     lineHeight: 20,
   },

--- a/src/screens/UserAAuthorizedScreens/SolutionsDetailsScreen/SolutionDetailsScreen.tsx
+++ b/src/screens/UserAAuthorizedScreens/SolutionsDetailsScreen/SolutionDetailsScreen.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
-import { Image, StyleSheet, View } from 'react-native';
+import { Image, Pressable, StyleSheet, View } from 'react-native';
 
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { SolutionsFeedStackParams } from 'src/navigation/Stacks/SolutionsFeedStack';
 
+import { openUrl } from 'src/utils';
 import useApiClient from 'src/hooks/useApiClient';
 import Myth from 'src/types/Myth';
 import Screen from 'src/components/Screen/Screen';
@@ -14,7 +15,6 @@ import ActionCardHeader from '../ClimateFeedScreen/ActionCardHeader';
 import DetailsSourcesTab from 'src/components/DetailsSourcesTabs';
 import { CmTypography } from 'src/components';
 import BackButton from 'src/components/BackButton';
-import { A } from '@expo/html-elements';
 
 type Props = NativeStackScreenProps<SolutionsFeedStackParams, 'SolutionDetailsScreen'>;
 
@@ -55,7 +55,9 @@ function SolutionDetailsScreen({ navigation, route }: Props) {
             {myths?.map(myth => <View style={{ margin: 10 }} key={myth.iri}><MythsFeedCard myth={myth} onLearnMore={null} /></View>)}
             </View>}
 
-          {selectedTab === 1 && solution.solutionSources.map(source => <View key={source} style={{ padding: 10 }}><CmTypography variant='label' style={styles.link}><A href={source}>{source}</A></CmTypography></View>)}
+          {selectedTab === 1 && solution.solutionSources.map(source => <View key={source} style={styles.links}>
+            <Pressable onPress={() => openUrl(source)}><CmTypography variant='label' style={styles.link}>{source}</CmTypography></Pressable>
+          </View>)}
         </Content>
       </Section>
     </Screen>
@@ -73,8 +75,12 @@ const styles = StyleSheet.create({
     lineHeight: 20,
     padding: 20,
   },
+  links: {
+    alignSelf: 'flex-start',
+  },
   link: {
     paddingHorizontal: 20,
+    marginTop: 20,
     textDecorationLine: 'underline',
     lineHeight: 20,
   },

--- a/src/screens/UserAAuthorizedScreens/SolutionsDetailsScreen/SolutionDetailsScreen.tsx
+++ b/src/screens/UserAAuthorizedScreens/SolutionsDetailsScreen/SolutionDetailsScreen.tsx
@@ -14,6 +14,7 @@ import ActionCardHeader from '../ClimateFeedScreen/ActionCardHeader';
 import DetailsSourcesTab from 'src/components/DetailsSourcesTabs';
 import { CmTypography } from 'src/components';
 import BackButton from 'src/components/BackButton';
+import { A } from '@expo/html-elements';
 
 type Props = NativeStackScreenProps<SolutionsFeedStackParams, 'SolutionDetailsScreen'>;
 
@@ -54,7 +55,7 @@ function SolutionDetailsScreen({ navigation, route }: Props) {
             {myths?.map(myth => <View style={{ margin: 10 }} key={myth.iri}><MythsFeedCard myth={myth} onLearnMore={null} /></View>)}
             </View>}
 
-          {selectedTab === 1 && solution.solutionSources.map(source => <View key={source} style={{ padding: 10 }}><CmTypography variant='label' style={styles.link}>{source}</CmTypography></View>)}
+          {selectedTab === 1 && solution.solutionSources.map(source => <View key={source} style={{ padding: 10 }}><CmTypography variant='label' style={styles.link}><A href={source}>{source}</A></CmTypography></View>)}
         </Content>
       </Section>
     </Screen>


### PR DESCRIPTION
<!-- title: [CLOSES #<issue_number>] Title of the Pull Request -->

## Description
Corrected styling on cimatDetailsScreen

## Changes Made
Changed the ActionCardHeader width to be 100% on the parent container and split percentage between image and text

## Screenshots
If applicable, add screenshots to showcase the changes visually.
<!-- After copy / pasting an image here, you can put the source in an img tag to choose a width for the image -->
<!-- <img src="" width=300 /> -->

## Checklist
- [x] I have tested this code.
- [x] I have updated the documentation.
- [x] I don't add technical debt with this pr.

## Additional Comments
Add any additional comments or notes for reviewers.
