### PR TITLE
Remove cyclic dependencies

### DIFF
--- a/src/features/conversations/components/SeeHowYouAlignModal.tsx
+++ b/src/features/conversations/components/SeeHowYouAlignModal.tsx
@@ -9,7 +9,7 @@ import { GetAllConversations } from 'src/api/responses';
 import useApiClient from 'src/hooks/useApiClient';
 import Alignment from 'src/types/Alignment';
 import { CmTypography, Content } from '@shared/components';
-import { PersonalValueCardSmall } from '@features/conversations/components';
+import PersonalValueCardSmall from './PersonalValueCardSmall';
 
 interface Props {
   open: boolean;

--- a/src/shared/components/BackButton.tsx
+++ b/src/shared/components/BackButton.tsx
@@ -1,7 +1,7 @@
 import { Pressable, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
-import { CmTypography } from '@shared/components';
+import CmTypography from './CmTypography';
 
 
 

--- a/src/shared/components/BulletListItem.tsx
+++ b/src/shared/components/BulletListItem.tsx
@@ -1,7 +1,7 @@
 import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 import { Entypo } from '@expo/vector-icons';
 
-import { CmTypography } from '@shared/components';
+import CmTypography from './CmTypography';
 
 interface Props {
   children: string;

--- a/src/shared/components/CmChip.tsx
+++ b/src/shared/components/CmChip.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
 
-import { CmTypography } from '@shared/components';
+import CmTypography from './CmTypography';
 
 interface Props {
   label: string;

--- a/src/shared/components/CmTextButton.tsx
+++ b/src/shared/components/CmTextButton.tsx
@@ -1,5 +1,5 @@
 import { Pressable, StyleProp, StyleSheet, ViewStyle } from 'react-native';
-import { CmTypography } from '@shared/components';
+import CmTypography from './CmTypography';
 
 interface Props {
   text: string;

--- a/src/shared/components/DetailsSourcesTabs.tsx
+++ b/src/shared/components/DetailsSourcesTabs.tsx
@@ -3,7 +3,7 @@ import { Pressable, StyleSheet, View } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { FontAwesome } from '@expo/vector-icons';
 
-import { CmTypography } from '@shared/components';
+import CmTypography from './CmTypography';
 
 interface Props {
   detailsTabName?: string;


### PR DESCRIPTION
<!-- title: [CLOSES #<issue_number>] Title of the Pull Request -->

## Description
As you can see in the screenshot below, there were cyclic dependencies.
So the `index.ts`in the @shared/components folder imported eg. `CmChip` and in there was an `import { CmTypography } from @shared/components`. To break the cyclic dependency, we import the CmTypography directly from the file, not from the index.ts file.

So in general, everything that is in the shared folder can depend on each other directly, not through the index.ts file of the shared folder. The same goes also for feature folders. Components inside the same feature folder should import 'themselves' directly, so not through the index.ts file. See the change for the PersonalValueCardSmall.

## Changes Made
Importing CmTypography directly, not from the index.ts file.
Importing PersonalValueCardSmall directly in the SeeHowYouAlignModal.

## Screenshots
If applicable, add screenshots to showcase the changes visually.
<!-- After copy / pasting an image here, you can put the source in an img tag to choose a width for the image -->
<!-- <img src="" width=300 /> -->
![image](https://github.com/ClimateMind/frontend-native-app/assets/78958483/a67db834-e35c-4d63-beca-0490da28d48a)

## Checklist
- [X] I have tested this code.
- [X] I have updated the documentation.
- [X] I don't add technical debt with this pr.

