### PR TITLE
Update App Button in Dev Screen

### DIFF
--- a/src/features/dev/components/UpdateButton.tsx
+++ b/src/features/dev/components/UpdateButton.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { StyleSheet } from "react-native";
+import * as Updates from 'expo-updates';
+
+import { CmButton } from "src/shared/components";
+import { useToastMessages } from "src/shared/hooks";
+
+function UpdateButton() {
+  const { showSuccessToast, showErrorToast } = useToastMessages();
+
+  const [buttonText, setButtonText] = useState("Update App");
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Check for new updates, and if available, download and install them
+  async function updateApp() {
+    setIsLoading(true);
+
+    try {
+      setButtonText("Checking for updates...");
+      const update = await Updates.checkForUpdateAsync();
+
+      if (update.isAvailable) {
+        setButtonText("Updating App...");
+        await Updates.fetchUpdateAsync();
+        await Updates.reloadAsync();
+      } else {
+        showSuccessToast('App is up to date');
+      }
+    } catch (error) {
+      showErrorToast('Error fetching latest Expo update');
+    } finally {
+      setIsLoading(false);
+      setButtonText("Update App");
+    }
+  }
+
+  return (
+    <CmButton isLoading={isLoading} onPress={updateApp} text={buttonText} style={styles.button} />
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    alignSelf: "stretch",
+    marginHorizontal: 20,
+    marginBottom: 20,
+  },
+});
+
+export default UpdateButton;

--- a/src/features/dev/components/index.ts
+++ b/src/features/dev/components/index.ts
@@ -1,0 +1,1 @@
+export { default as UpdateButton } from './UpdateButton';

--- a/src/features/dev/index.ts
+++ b/src/features/dev/index.ts
@@ -1,0 +1,1 @@
+export * from './components';

--- a/src/screens/DevScreen/DevScreen.tsx
+++ b/src/screens/DevScreen/DevScreen.tsx
@@ -1,5 +1,9 @@
+import { StyleSheet, View } from 'react-native';
+
+import appConfig from '../../../app.json';
 import { CmButton, CmTypography, Content, Screen } from 'src/shared/components';
 import { useOnboarding } from 'src/features/onboarding/hooks';
+import { UpdateButton } from 'src/features/dev';
 
 function DevScreen() {
   const { resetOnboarding } = useOnboarding();
@@ -11,10 +15,23 @@ function DevScreen() {
           Dev Screen
         </CmTypography>
 
-        <CmButton onPress={resetOnboarding} text="Reset Onboarding" />
+        <CmButton onPress={resetOnboarding} text="Reset Onboarding" style={styles.btn} />
+
+        <UpdateButton />
+
+        <View style={{ flex: 1 }} />
+        <CmTypography variant='body' style={{ marginBottom: 20 }}>Version {appConfig.expo.version}</CmTypography>
       </Content>
     </Screen>
   );
 }
+
+const styles = StyleSheet.create({
+  btn: {
+    alignSelf: 'stretch',
+    marginHorizontal: 20,
+    marginBottom: 20,
+  },
+});
 
 export default DevScreen;


### PR DESCRIPTION
<!-- title: [CLOSES #<issue_number>] Title of the Pull Request -->

## Description
Currently when you start the app, it looks for updates and downloads them if available. The second time you open the app (if you waited long enough for the download to complete), it will load the new version. This behavior is hard to comprehend if you don't know about it and as we don't have a proper version number anywhere, it is impossible to tell if you have the newest version of the app or not. Eg. when we make a bug fix / add a new feature and Kameron wants to test it, he can't really know if he is on the right version or not.

This PR will add a new button to the dev screen to update the app. In development, this button always throws an error, because the updating mechanism only works in production. So I'd propose to simply merge this PR and see if it works after the next *eas update*. As it is on the Dev Screen, it shouldn't affect users in any way, even if the implementation would be broken.

Furthermore, a version number is added at the bottom of the Dev Screen. This version number is currently static `1.0.1` and we don't change it at any point. With this PR, I only want to test if reading it from the app.json file works in production as well. We'll work in a future PR on implementing a proper mechanism to update the version and keeping track of a changelog. We might also want to add this version number at a place where users can see it (eg. at the bottom of the drawer or at the bottom of the start screen), so that a user that wants to report a bug or has a question can add the version number he's currently on, because maybe the bug has been addressed already in a newer version.

## Changes Made
- Added a new feature folder that we can use for dev stuff to implement the UpdateButton component
- Added the button and the version number to the Dev Screen

## Screenshots
<!-- After copy / pasting an image here, you can put the source in an img tag to choose a width for the image -->
<img src="https://github.com/ClimateMind/frontend-native-app/assets/78958483/78bc5661-c22e-48ab-baef-046d0abd6049" width=300 />

## Checklist
- [X] I have tested this code.
- [X] I have updated the documentation.
- [X] I don't add technical debt with this pr.
