### PR TITLE
[CLOSES #315] Hide back button when no history left

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { SafeAreaView, StyleSheet } from 'react-native';
 import { RootSiblingParent } from 'react-native-root-siblings';
 import { NavigationContainer, useNavigationContainerRef } from '@react-navigation/native';
@@ -17,6 +17,8 @@ import { analyticsService } from 'src/services';
 SplashScreen.preventAutoHideAsync();
 
 function App() {
+  const [canGoBack, setCanGoBack] = useState(false);
+
   const navigationRef = useNavigationContainerRef();
   const routeNameRef = useRef<any>();
 
@@ -43,6 +45,8 @@ function App() {
             ref={navigationRef}
             onReady={() => {
               routeNameRef.current = navigationRef?.getCurrentRoute()?.name;
+
+              setCanGoBack(navigationRef.canGoBack());
               analyticsService.setScreenName(routeNameRef.current);
             }}
             onStateChange={() => {
@@ -53,12 +57,12 @@ function App() {
                 // Save the current route name for later comparison
                 routeNameRef.current = currentRouteName;
 
-                // Replace the line below to add the tracker from a mobile analytics SDK
+                setCanGoBack(navigationRef.canGoBack());
                 analyticsService.setScreenName(currentRouteName ?? 'undefined');
               }
             }}
           >
-            <NavigationRoot />
+            <NavigationRoot canGoBack={canGoBack} />
           </NavigationContainer>
         </SafeAreaView>
       </RootSiblingParent>

--- a/src/navigation/NavigationRoot.tsx
+++ b/src/navigation/NavigationRoot.tsx
@@ -34,7 +34,11 @@ export type RootDrawerNavigationParams = {
 
 const RootDrawer = createDrawerNavigator<RootDrawerNavigationParams>();
 
-function NavigationRoot() {
+interface Props {
+  canGoBack: boolean;
+}
+
+function NavigationRoot({ canGoBack }: Props) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
   const sessionId = useAppSelector((state) => state.auth.sessionId);
@@ -91,7 +95,10 @@ function NavigationRoot() {
         headerStyle: { backgroundColor: Colors.themeDark },
         headerTintColor: 'white',
         headerTitleAlign: 'center',
-        headerLeft: () => <Ionicons name="chevron-back" size={24} color="white" onPress={() => navigation.goBack()} style={{ padding: 10, paddingRight: 20 }} />,
+        headerLeft: () => {
+          if (!canGoBack) return null;
+          return <Ionicons name="chevron-back" size={24} color="white" onPress={() => navigation.goBack()} style={{ padding: 10, paddingRight: 20 }} />
+        },
         headerRight: () => <DrawerToggleButton tintColor='white' />,
         headerTitle: () => (
           <Pressable delayLongPress={5000} onLongPress={() => navigation.navigate('DevScreen')}>


### PR DESCRIPTION
<!-- title: [CLOSES #<issue_number>] Title of the Pull Request -->

## Description
When there is no screen to go back to, we want to hide the go back button on the top left.

## Changes Made
- Added the canGoBack state, which we take from the NavigationContainer
- Passing this as a prop to the NavigationRoot to hide the back button when there is no screen to go back to

## Checklist
- [X] I have tested this code.
- [X] I have updated the documentation.
- [X] I don't add technical debt with this pr.

