### PR TITLE
Bugfix: Remove 500 Errors in Conversation Dashboard

### DIFF
--- a/src/features/conversations/components/ConversationCard.tsx
+++ b/src/features/conversations/components/ConversationCard.tsx
@@ -120,7 +120,7 @@ function ConversationCard({ conversation, onDelete }: Props) {
         </View>
 
         <SeeHowYouAlignModal conversation={conversation} open={showSeeHowYouAlignModal} onClose={() => setShowSeeHowYouAlignModal(false)} onViewTopics={() => {setShowSeeHowYouAlignModal(false); setShowViewSelectedTopicsModal(true);}} />
-        <ViewSelectedTopicsModal conversation={conversation} open={showViewSelectedTopicsModal} onClose={() => setShowViewSelectedTopicsModal(false)} />
+        <ViewSelectedTopicsModal conversation={conversation} conversationState={conversationState} open={showViewSelectedTopicsModal} onClose={() => setShowViewSelectedTopicsModal(false)} />
 
         <DeleteConversationModal show={showDeleteModal} userBName={userBName} onCancel={() => setShowDeleteModal(false)} onConfirm={deleteConversation} />
 

--- a/src/features/conversations/components/ViewSelectedTopicsButton.tsx
+++ b/src/features/conversations/components/ViewSelectedTopicsButton.tsx
@@ -13,12 +13,14 @@ function ViewSelectedTopicsButton({ conversationId, conversationState, style, on
   const apiClient = useApiClient();
 
   function handleButtonClick() {
-    apiClient.putSingleConversation({
-      conversationId,
-      updatedConversation: {
-        state: 3,
-      },
-    });
+    if (conversationState < 3) {
+      apiClient.putSingleConversation({
+        conversationId,
+        updatedConversation: {
+          state: 3,
+        },
+      });
+    }
 
     onClick();
   }

--- a/src/features/conversations/components/ViewSelectedTopicsModal.tsx
+++ b/src/features/conversations/components/ViewSelectedTopicsModal.tsx
@@ -16,10 +16,11 @@ import { CmTypography, Content } from '@shared/components';;
 interface Props {
   open: boolean;
   conversation: GetAllConversations;
+  conversationState: number;
   onClose: () => void;
 }
 
-function ViewSelectedTopicsModal({ open, conversation, onClose }: Props) {
+function ViewSelectedTopicsModal({ open, conversation, conversationState, onClose }: Props) {
   const apiClient = useApiClient();
 
   const [climateEffect, setClimateEffect] = useState<ClimateEffect2>();
@@ -31,7 +32,7 @@ function ViewSelectedTopicsModal({ open, conversation, onClose }: Props) {
   const [showSolutionDetails, setShowSolutionDetails] = useState(false);
 
   useEffect(() => {
-    if (conversation.conversationId) {
+    if (conversation.conversationId && conversationState > 2) {
       apiClient.getSelectedTopics(conversation.conversationId)
         .then(response => {
           setClimateEffect(response.climateEffects[0]);
@@ -40,7 +41,7 @@ function ViewSelectedTopicsModal({ open, conversation, onClose }: Props) {
         })
         .catch((error) => console.log(error));
     }
-  }, [conversation]);
+  }, [conversation, conversationState]);
 
   if (!open || !climateEffect || !climateSolutions || !solutionDetails) {
     return null;


### PR DESCRIPTION
<!-- title: [CLOSES #<issue_number>] Title of the Pull Request -->

## Description
Right now if you are on the main branch, login, go to the conversation screen and open the drawer with all the conversation cards, you will probably get some console log statements like in the screenshot below. The number of errors depends on the amount of conversation cards you have and the state they are in.

![image](https://github.com/ClimateMind/frontend-native-app/assets/78958483/0df740ed-bc7b-4d29-abb2-da8b99f11d69)

Those error messages came from the ViewSelectedTopicsModal, because it wanted to call `apiClient.getSelectedTopics` for conversations that weren't in a conversation state where this call is possible. So by adding an if check for the conversation state before the api call, the errors disappeared.

## Checklist
- [X] I have tested this code.
- [X] I have updated the documentation.
- [X] I don't add technical debt with this pr.

## Additional Comments
I checked that I don't add technical debt with this pr, which probably is true. But there is already existing technical debt that we need to address in the future. This involves cleaning up the components and extracting the logic into hooks, similar to the quiz refactoring we did.
