### PR TITLE
[CLOSES #476] Create CmBackButton to replace all back buttons

### DIFF
--- a/src/features/conversations/components/SeeHowYouAlignModal.tsx
+++ b/src/features/conversations/components/SeeHowYouAlignModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
-import Colors from 'src/assets/colors';
 
+import Colors from 'src/assets/colors';
 import ViewSelectedTopicsButton from './ViewSelectedTopicsButton';
 import { GetAllConversations } from 'src/api/responses';
 import useApiClient from 'src/hooks/useApiClient';
@@ -51,9 +51,7 @@ function SeeHowYouAlignModal({ open, conversation, onClose, onViewTopics }: Prop
       <View style={styles.container}>
         <Content>
           <ScrollView>
-            <View style={styles.backButtonContainer}>
-            <BackButton onPress={onClose}/>
-            </View>
+            <BackButton onPress={onClose} style={{ marginVertical: 25 }} />
 
             <CmTypography variant='h1'>Your shared core values!</CmTypography>
 
@@ -80,16 +78,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     padding: 20,
     backgroundColor: Colors.themeBright,
-  },
-  backButtonContainer: {
-    alignSelf: 'flex-start',
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginVertical: 20,
-    paddingTop: 10,
-  },
-  backButtonText: {
-    marginLeft: 10,
   },
   subheader: {
     textAlign: 'center',

--- a/src/features/conversations/components/SeeHowYouAlignModal.tsx
+++ b/src/features/conversations/components/SeeHowYouAlignModal.tsx
@@ -1,14 +1,12 @@
 import { useEffect, useState } from 'react';
-import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
-
+import { ScrollView, StyleSheet, View } from 'react-native';
 import Colors from 'src/assets/colors';
 
 import ViewSelectedTopicsButton from './ViewSelectedTopicsButton';
 import { GetAllConversations } from 'src/api/responses';
 import useApiClient from 'src/hooks/useApiClient';
 import Alignment from 'src/types/Alignment';
-import { CmModal, CmTypography, Content } from '@shared/components';
+import { CmModal, CmTypography, Content, BackButton } from '@shared/components';
 import PersonalValueCardSmall from './PersonalValueCardSmall';
 
 interface Props {
@@ -53,10 +51,9 @@ function SeeHowYouAlignModal({ open, conversation, onClose, onViewTopics }: Prop
       <View style={styles.container}>
         <Content>
           <ScrollView>
-            <Pressable style={styles.backButtonContainer} onPress={onClose}>
-              <Ionicons name="chevron-back-outline" size={24} color="#A347FF" />
-              <CmTypography variant='button' style={styles.backButtonText}>BACK</CmTypography>
-            </Pressable>
+            <View style={styles.backButtonContainer}>
+            <BackButton onPress={onClose}/>
+            </View>
 
             <CmTypography variant='h1'>Your shared core values!</CmTypography>
 
@@ -89,7 +86,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     marginVertical: 20,
-    paddingTop: 30,
+    paddingTop: 10,
   },
   backButtonText: {
     marginLeft: 10,

--- a/src/features/conversations/components/ViewSelectedTopicsModal.tsx
+++ b/src/features/conversations/components/ViewSelectedTopicsModal.tsx
@@ -1,9 +1,9 @@
+import { useEffect, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 
 import Colors from 'src/assets/colors';
 import { GetAllConversations } from 'src/api/responses';
 import useApiClient from 'src/hooks/useApiClient';
-import { useEffect, useState } from 'react';
 import ClimateEffect2 from 'src/types/ClimateEffect2';
 import Solution3 from 'src/types/Solution3';
 import ActionCard from './ActionCard';
@@ -56,9 +56,7 @@ function ViewSelectedTopicsModal({ open, conversation, conversationState, onClos
       <View style={styles.container}>
         <Content>
           <ScrollView>
-          <View style={styles.backButtonContainer}>
-            <BackButton onPress={onClose}/>
-            </View>
+            <BackButton onPress={onClose} style={{ marginVertical: 25 }} />
 
             <CmTypography variant='h1'>Your shared feed with {conversation.userB.name}</CmTypography>
 
@@ -91,16 +89,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     padding: 20,
     backgroundColor: Colors.themeBright,
-  },
-  backButtonContainer: {
-    alignSelf: 'flex-start',
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginVertical: 20,
-    paddingTop: 10,
-  },
-  backButtonText: {
-    marginLeft: 10,
   },
   text: {
     textAlign: 'center',

--- a/src/features/conversations/components/ViewSelectedTopicsModal.tsx
+++ b/src/features/conversations/components/ViewSelectedTopicsModal.tsx
@@ -1,5 +1,4 @@
-import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import { ScrollView, StyleSheet, View } from 'react-native';
 
 import Colors from 'src/assets/colors';
 import { GetAllConversations } from 'src/api/responses';
@@ -11,7 +10,7 @@ import ActionCard from './ActionCard';
 import SolutionsFeedCard from './SolutionCard';
 import SolutionDetailsModal from './SolutionDetailsModal';
 import ActionDetailsModal from './ActionDetailsModal';
-import { CmModal, CmTypography, Content } from '@shared/components';;
+import { BackButton, CmModal, CmTypography, Content } from '@shared/components';;
 
 interface Props {
   open: boolean;
@@ -57,10 +56,9 @@ function ViewSelectedTopicsModal({ open, conversation, conversationState, onClos
       <View style={styles.container}>
         <Content>
           <ScrollView>
-            <Pressable style={styles.backButtonContainer} onPress={onClose}>
-              <Ionicons name="chevron-back-outline" size={24} color="#A347FF" />
-              <CmTypography variant='button' style={styles.backButtonText}>BACK</CmTypography>
-            </Pressable>
+          <View style={styles.backButtonContainer}>
+            <BackButton onPress={onClose}/>
+            </View>
 
             <CmTypography variant='h1'>Your shared feed with {conversation.userB.name}</CmTypography>
 
@@ -99,7 +97,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     marginVertical: 20,
-    paddingTop: 30,
+    paddingTop: 10,
   },
   backButtonText: {
     marginLeft: 10,

--- a/src/shared/components/BackButton.tsx
+++ b/src/shared/components/BackButton.tsx
@@ -1,17 +1,16 @@
-import { Pressable, StyleSheet } from 'react-native';
+import { Pressable, StyleProp, StyleSheet, ViewStyle } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
 import CmTypography from './CmTypography';
 
-
-
 interface Props {
   onPress: () => void;
+  style?: StyleProp<ViewStyle>;
 }
 
-function BackButton({ onPress }: Props) {
+function BackButton({ onPress, style }: Props) {
   return (
-    <Pressable style={styles.backButtonContainer} onPress={onPress}>
+    <Pressable style={[styles.backButtonContainer, style]} onPress={onPress}>
       <Ionicons name="chevron-back-outline" size={24} color="#A347FF" />
       <CmTypography variant='button' style={styles.backButtonText}>
         BACK
@@ -25,7 +24,9 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-start',
     flexDirection: 'row',
     alignItems: 'center',
-    marginVertical: 20
+    // Padding to make the button easier to press
+    paddingVertical: 5,
+    paddingRight: 10,
   },
   backButtonText: {
     marginLeft: 10,

--- a/src/shared/components/BackButton.tsx
+++ b/src/shared/components/BackButton.tsx
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-start',
     flexDirection: 'row',
     alignItems: 'center',
-    marginVertical: 20,
+    marginVertical: 20
   },
   backButtonText: {
     marginLeft: 10,


### PR DESCRIPTION
[CLOSES #476] create-cmbackbutton-to-replace-all-back-buttons 

## Description
Found an existing BackButton component and imported it to the SeeHowYouAlignModal and ViewSelectedTopicsModal

## Changes Made
Found an existing BackButton component and imported it to the SeeHowYouAlignModal and ViewSelectedTopicsModal
Created a view to contain the modal so that I could adjust the button margin height so that it cleared the top of the IOS screen.

## Screenshots
If applicable, add screenshots to showcase the changes visually.
<!-- After copy / pasting an image here, you can put the source in an img tag to choose a width for the image -->
<!-- <img src="" width=300 /> -->

## Checklist
- [x] I will open the PR as a draft and will look at the 'Files Changed' tab to remove all unnecessary changes.

## Additional Comments
Add any additional comments or notes for reviewers.
