### PR TITLE
[CLOSES #474] Alternative approach to simplify emoji buttons

### DIFF
--- a/src/features/conversations/components/ConversationRating.tsx
+++ b/src/features/conversations/components/ConversationRating.tsx
@@ -54,16 +54,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     marginTop: 20,
   },
-  button: {
-    width: 50,
-    height: 50,
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderWidth: 1,
-    borderRadius: 5,
-    borderColor: '#A347FF',
-    backgroundColor: 'white',
-  },
 });
 
 export default ConversationRating;

--- a/src/features/conversations/components/ConversationRating.tsx
+++ b/src/features/conversations/components/ConversationRating.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-import { Pressable, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 import useApiClient from 'src/hooks/useApiClient';
-import { CmTypography } from '@shared/components';
+import { CmButton, CmTypography } from '@shared/components';
 
 interface Props {
   conversationId: string;
@@ -33,11 +33,11 @@ function ConversationRating({ conversationId, initialRating, onRated }: Props) {
       <CmTypography variant="body">How Did it go?</CmTypography>
 
       <View style={styles.buttonContainer}>
-        <Pressable style={[styles.button, { backgroundColor: rating === 1 ? 'lightgray' : 'white'}]} onPress={() => submitRating(1)}><CmTypography variant='body'>😡</CmTypography></Pressable>
-        <Pressable style={[styles.button, { backgroundColor: rating === 2 ? 'lightgray' : 'white'}]} onPress={() => submitRating(2)}><CmTypography variant='body'>😐</CmTypography></Pressable>
-        <Pressable style={[styles.button, { backgroundColor: rating === 3 ? 'lightgray' : 'white'}]} onPress={() => submitRating(3)}><CmTypography variant='body'>🤔</CmTypography></Pressable>
-        <Pressable style={[styles.button, { backgroundColor: rating === 4 ? 'lightgray' : 'white'}]} onPress={() => submitRating(4)}><CmTypography variant='body'>😊</CmTypography></Pressable>
-        <Pressable style={[styles.button, { backgroundColor: rating === 5 ? 'lightgray' : 'white'}]} onPress={() => submitRating(5)}><CmTypography variant='body'>🥳</CmTypography></Pressable>
+        <CmButton text='😡' color='userb' style={{ paddingHorizontal: 7, backgroundColor: rating === 1 ? 'lightgray' : 'white'}} onPress={() => submitRating(1)} />
+        <CmButton text='😐' color='userb' style={{ paddingHorizontal: 7, backgroundColor: rating === 2 ? 'lightgray' : 'white'}} onPress={() => submitRating(2)} />
+        <CmButton text='🤔' color='userb' style={{ paddingHorizontal: 7, backgroundColor: rating === 3 ? 'lightgray' : 'white'}} onPress={() => submitRating(3)} />
+        <CmButton text='😊' color='userb' style={{ paddingHorizontal: 7, backgroundColor: rating === 4 ? 'lightgray' : 'white'}} onPress={() => submitRating(4)} />
+        <CmButton text='🥳' color='userb' style={{ paddingHorizontal: 7, backgroundColor: rating === 5 ? 'lightgray' : 'white'}} onPress={() => submitRating(5)} />
       </View>
     </>
   );

--- a/src/shared/components/CmButton.tsx
+++ b/src/shared/components/CmButton.tsx
@@ -4,7 +4,7 @@ import CmTypography from './CmTypography';
 interface Props {
   text: string;
   onPress?: () => void;
-  color?: 'success' | 'error';
+  color?: 'success' | 'error' | 'userb';
   style?: StyleProp<ViewStyle>;
   disabled?: boolean;
   startIcon?: React.ReactNode;
@@ -12,13 +12,26 @@ interface Props {
 }
 
 function CmButton({ text, onPress = () => {}, color = 'success', style = {}, disabled = false, startIcon, isLoading = false }: Props) {  
+  let borderColor: string;
+  switch (color) {
+    case 'error':
+      borderColor = '#FF0000';
+      break;
+    case 'userb':
+      borderColor = '#A346FF';
+      break;
+    default:
+      borderColor = '#39F5AD';
+      break;
+  }
+
   return (
     <Pressable
       disabled={isLoading || disabled}
       onPress={onPress}
       style={({ pressed }) => [
         styles.button,
-        color === 'error' && { borderColor: '#ff0000' },
+        { borderColor },
         pressed && styles.buttonPressed,
         (disabled || isLoading) && styles.buttonDisabled,
         style,
@@ -43,7 +56,6 @@ const styles = StyleSheet.create({
   button: {
     backgroundColor: 'white',
     borderRadius: 5,
-    borderColor: '#39f5ad',
     borderWidth: 1,
     minHeight: 50,
     paddingHorizontal: 20,


### PR DESCRIPTION
<!-- title: [CLOSES #<issue_number>] Title of the Pull Request -->

## Description
Alternative to [this PR](https://github.com/ClimateMind/frontend-native-app/pull/475), simplifying the emoji buttons in the ConversationRating component a bit.

## Changes Made
Add userb border color to CmButton and change the Pressables in the ConversationRating to CmButtons.

## Screenshots
If applicable, add screenshots to showcase the changes visually.
<!-- After copy / pasting an image here, you can put the source in an img tag to choose a width for the image -->
<!-- <img src="" width=300 /> -->

## Checklist
- [X] I will open the PR as a draft and will look at the 'Files Changed' tab to remove all unnecessary changes.

## Additional Comments
Add any additional comments or notes for reviewers.
