### PR TITLE
Decreaes Vertical Space Between Chips

### DIFF
--- a/src/features/climate-feed/components/ClimateFeedCard.tsx
+++ b/src/features/climate-feed/components/ClimateFeedCard.tsx
@@ -31,7 +31,7 @@ function ClimateFeedCard({ climateEffect, onLearnMore }: Props) {
       {climateEffect.relatedPersonalValues && (
         <View style={styles.chipsContainer}>
           {climateEffect.relatedPersonalValues.map((value, index) => (
-            <View key={value} style={{ marginRight: 10, marginBottom: 10 }}>
+            <View key={value} style={{ marginRight: 10 }}>
               {activeTooltipIndex === index && <CmTooltip value={value} fadeAnim={fadeAnim} />}
               <Pressable onPress={() => toggleTooltip(index)}>
                 <CmChip label={value} />

--- a/src/features/conversations/components/ActionCard.tsx
+++ b/src/features/conversations/components/ActionCard.tsx
@@ -40,7 +40,7 @@ function ActionCard({ climateEffect, onLearnMore }: Props) {
       {climateEffect.relatedPersonalValues && (
         <View style={styles.chipsContainer}>
           {climateEffect.relatedPersonalValues.map((value, index) => (
-            <View key={value} style={{ marginRight: 10, marginBottom: 10 }}>
+            <View key={value} style={{ marginRight: 10 }}>
               {activeTooltipIndex === index && <CmTooltip value={value} fadeAnim={fadeAnim} />}
               <Pressable onPress={() => toggleTooltip(index)}>
                 <CmChip key={value} label={value} />

--- a/src/screens/SharedScreens/DevScreen.tsx
+++ b/src/screens/SharedScreens/DevScreen.tsx
@@ -184,6 +184,7 @@ function DevScreen() {
           />
         </>
       )}
+
       <Content style={{ padding: 20 }}>
         <View style={{ flex: 1 }} />
 


### PR DESCRIPTION
<!-- title: [CLOSES #<issue_number>] Title of the Pull Request -->

## Description
I find the vertical space between the related personal value chips a bit too large. See screenshots below for comparison.

## Changes Made
- Remove marginBottom for related personal value chips

## Screenshots
Left before, right after.
<!-- After copy / pasting an image here, you can put the source in an img tag to choose a width for the image -->
<img src="https://github.com/ClimateMind/frontend-native-app/assets/78958483/17969c33-8716-4e94-9aa9-f6fa646389cf" width=300 />
<img src="https://github.com/ClimateMind/frontend-native-app/assets/78958483/dae34197-1fe8-4cc3-876c-c92c37038cdd" width=300 />

## Checklist
- [X] I will open the PR as a draft and will look at the 'Files Changed' tab to remove all unnecessary changes.
