### PR TITLE
[CLOSES #560] Add logic to make sure that if one card has a tooltip then another shouldn't be opened 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6175,13 +6175,13 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.2.73",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.73.tgz",
       "integrity": "sha512-XcGdod0Jjv84HOC7N5ziY3x+qL0AfmubvKOZ9hJjJ2yd5EE+KYjWhdOjt387e9HPheHkdggF9atTifMRtyAaRA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -7437,7 +7437,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/dag-map": {
       "version": "1.0.2",

--- a/src/screens/UserAAuthorizedScreens/ClimateFeedScreen.tsx
+++ b/src/screens/UserAAuthorizedScreens/ClimateFeedScreen.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { ActivityIndicator, FlatList, StyleSheet, View } from 'react-native';
+import { useEffect, useRef, useState } from 'react';
+import { ActivityIndicator, Animated, Dimensions, FlatList, StyleSheet, View } from 'react-native';
 
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { ClimateFeedStackParams } from 'src/navigation/Stacks/ClimateFeedStack';
@@ -9,6 +9,7 @@ import ClimateEffect from 'src/types/ClimateEffect';
 import { CmTypography, Screen, Content, Section } from '@shared/components';
 import { ClimateFeedCard } from '@features/climate-feed/components';
 import { useAppSelector } from 'src/store/hooks';
+import { useCmTooltip } from 'src/shared/hooks';
 
 type Props = NativeStackScreenProps<ClimateFeedStackParams, 'ClimateFeedScreen'>;
 
@@ -16,6 +17,18 @@ function ClimateFeedScreen({ navigation }: Props) {
   const apiClient = useApiClient();
   const sessionId = useAppSelector((state) => state.auth.sessionId);
   const [climateFeed, setClimateFeed] = useState<ClimateEffect[]>();
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+  const { fadeOut } = useCmTooltip(fadeAnim);
+
+  const handleScroll = (event: { nativeEvent: { contentOffset: { y: number } } }) => {
+    // Set the threshold for scrolling
+    const threshold = Dimensions.get('window').height;
+    // Check if the user has scrolled beyond the threshold
+    if (event.nativeEvent.contentOffset.y > threshold) {
+      // Fade out the tooltip
+      fadeOut();
+    }
+  };
 
   function gotoDetailsScreen(climateEffect: ClimateEffect) {
     navigation.navigate('ClimateDetailsScreen', { climateEffect });
@@ -26,7 +39,7 @@ function ClimateFeedScreen({ navigation }: Props) {
   }, [sessionId]);
 
   if (climateFeed === undefined) {
-    return <ActivityIndicator size='large' color='black' style={{ marginTop: 100 }} />;
+    return <ActivityIndicator size="large" color="black" style={{ marginTop: 100 }} />;
   }
 
   return (
@@ -34,12 +47,14 @@ function ClimateFeedScreen({ navigation }: Props) {
       <Section style={{ paddingVertical: 0 }}>
         <Content style={{ alignItems: 'stretch' }}>
           <FlatList
+            onScroll={handleScroll}
             ListHeaderComponent={
               <>
-                <CmTypography variant='h1' style={styles.heading}>Explore climate change impacts</CmTypography>
-                <CmTypography variant='body' style={styles.text}>
-                  This is your personalized homepage based on your unique climate personality. Check out
-                  these articles to stay informed!
+                <CmTypography variant="h1" style={styles.heading}>
+                  Explore climate change impacts
+                </CmTypography>
+                <CmTypography variant="body" style={styles.text}>
+                  This is your personalized homepage based on your unique climate personality. Check out these articles to stay informed!
                 </CmTypography>
               </>
             }

--- a/src/shared/hooks/useCmTooltip.tsx
+++ b/src/shared/hooks/useCmTooltip.tsx
@@ -40,6 +40,7 @@ function useCmTooltip(fadeAnim: Animated.Value | Animated.ValueXY) {
     activeTooltipIndex,
     toggleTooltip,
     handleCardPress,
+    fadeOut,
   };
 }
 


### PR DESCRIPTION
[CLOSES #560] Add logic to make sure that if one card has a tooltip then another shouldn't be opened 

## Description
Add logic so that if the screen is scrolled outside of the current screen's height, then the tooltip fades out. So in summary, if we scroll and it passes the current threshold set in the code it closes the tooltip. 

## Changes Made

- Returned fadeOut from the useCMTooltip hook
- Added the following logic to the ClimateFeedScreen 

```
 const handleScroll = (event: { nativeEvent: { contentOffset: { y: number } } }) => {
    // Set the threshold for scrolling
    const threshold = Dimensions.get('window').height;
    // Check if the user has scrolled beyond the threshold
    if (event.nativeEvent.contentOffset.y > threshold) {
      // Fade out the tooltip
      fadeOut();
    }
  };
```

## Screenshots
If applicable, add screenshots to showcase the changes visually.
<!-- After copy / pasting an image here, you can put the source in an img tag to choose a width for the image -->
<!-- <img src="" width=300 /> -->

## Checklist
- [x] I will open the PR as a draft and will look at the 'Files Changed' tab to remove all unnecessary changes.

## Additional Comments
Add any additional comments or notes for reviewers.
